### PR TITLE
Add web frontend and GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy static site
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './docs'
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Quickstart
    jupyter lab simulations/simulation.ipynb
    ```
 6. Launch the interactive auxetic pattern simulator:
-   Simply open [`docs/auxetic_simulator.html`](docs/auxetic_simulator.html) in your web browser.
+   - Locally: open [`docs/auxetic_simulator.html`](docs/auxetic_simulator.html) in your web browser.
+   - Online: the simulator is deployed to **GitHub Pages**. After pushing to this repository, visit the URL shown in the Pages deployment to run it directly from your browser.
 
-   To access it from another device (e.g. your phone) on the same network, run:
+   To access it from another device on the same network, run:
    ```bash
    python scripts/serve_docs.py --host 0.0.0.0 --port 8000
    ```

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Capacitive Auxetic Sensor Simulator</title>
+  <style>
+    body { font-family: sans-serif; margin:0; }
+    header { background: #1976d2; color: #fff; padding: 1rem; text-align: center; }
+    main { padding: 1rem; }
+    iframe { width: 100%; height: 80vh; border: none; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Capacitive Auxetic Sensor Simulator</h1>
+  </header>
+  <main>
+    <p>Adjust parameters in the simulator below to explore how auxetic lattice geometry affects deformation.</p>
+    <iframe src="auxetic_simulator.html" title="Auxetic simulator"></iframe>
+  </main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add `docs/index.html` showcasing the auxetic simulator via an embedded iframe
- Configure GitHub Pages with a deploy workflow
- Document online simulator access in the README

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd0c1a6d808327a2e5cca10c0e3917